### PR TITLE
rz-ghidra: Use RIZIN_INSTALL_PLUGDIR instead

### DIFF
--- a/db/rz-ghidra
+++ b/db/rz-ghidra
@@ -9,7 +9,7 @@ RZPM_INSTALL() {
 	git submodule init && git submodule update || exit 1
 	rm -rf build # clean build
 	mkdir -p build && cd build || exit 1
-	cmake -DRADARE2_INSTALL_PLUGDIR="${RZPM_PLUGDIR}" .. || exit 1
+	cmake -DRIZIN_INSTALL_PLUGDIR="${RZPM_PLUGDIR}" .. || exit 1
 	${MAKE} -j${RZPM_JOBS} || exit 1
 	${MAKE} install || exit 1
 }


### PR DESCRIPTION
This pr allows the `rz-ghidra` plugin to be installed locally using `rz-pm -i`.