### PR TITLE
rz-ghidra: Add CMAKE_INSTALL_PREFIX to install locally

### DIFF
--- a/db/rz-ghidra
+++ b/db/rz-ghidra
@@ -9,7 +9,7 @@ RZPM_INSTALL() {
 	git submodule init && git submodule update || exit 1
 	rm -rf build # clean build
 	mkdir -p build && cd build || exit 1
-	cmake -DRIZIN_INSTALL_PLUGDIR="${RZPM_PLUGDIR}" .. || exit 1
+	cmake -DRIZIN_INSTALL_PLUGDIR="${RZPM_PLUGDIR}" -DCMAKE_INSTALL_PREFIX="${HOME}/.local" .. || exit 1
 	${MAKE} -j${RZPM_JOBS} || exit 1
 	${MAKE} install || exit 1
 }


### PR DESCRIPTION
#5 should have allowed the `rz-ghidra` plugin to be installed locally using `rz-pm -i` by using `RIZIN_INSTALL_PLUGDIR` but as rizinorg/rz-pm#10 shows `rz-ghidra` will still be installed in `/usr/local`, which requires root priviledge.
So I added `-DCMAKE_INSTALL_PREFIX=~/.local` as https://github.com/rizinorg/rz-ghidra#building says, it works now. I hope it will not affect `RIZIN_INSTALL_PLUGDIR`, though I could not find `RIZIN_INSTALL_PLUGDIR` anywhere.